### PR TITLE
Allow testing states on new models

### DIFF
--- a/acts_as_state_machine.gemspec
+++ b/acts_as_state_machine.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'acts_as_state_machine'
-  s.version = '3.0.5'
+  s.version = '3.0.6'
   s.date = '2013-03-26'
 
   s.summary = "Allows ActiveRecord models to define states and transition actions between them"

--- a/lib/acts_as_state_machine.rb
+++ b/lib/acts_as_state_machine.rb
@@ -156,7 +156,7 @@ module ScottBarron                   #:nodoc:
 
         # Returns the current state the object is in, as a Ruby symbol.
         def current_state
-          self.send(self.class.state_column).to_sym
+          self.send(self.class.state_column).try(:to_sym)
         end
 
         # Returns what the next state for a given event would be, as a Ruby symbol.
@@ -276,7 +276,7 @@ module ScottBarron                   #:nodoc:
 
         protected
         def _state_scope(state)
-          raise InvalidState unless states.include?(state.to_sym)
+          raise InvalidState unless states.include?(state.try(:to_sym))
           where(state_column => state.to_s)
         end
       end


### PR DESCRIPTION
This fix makes the following work:
- MyModel.new.my_state?
- MyModel.new.current_state

Otherwise they break because state is nil, which is inconvenient - for
example, you couldn't call those methods in a validation because it
would break first time you save.

Side note:

You could manually set the state before saving but you shouldn't have
to.  (IMO, acts_as_state_machine should set the state when the object
is initialized, not when it is persisted, but I'm not sure about the
implications to our codebase of changing this...)
